### PR TITLE
DC-Ops have reported issue with cert installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ define sslcertificate($name, $password, $location, $root_store = 'LocalMachine',
 
   exec { "Install-SSL-Certificate-${name}":
     path      => "${ps_path};${::path}",
-    command   => "${ps_command} -Command \"Import-Module WebAdministration; \$pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2; \$pfxPass = ConvertTo-SecureString \\\"${password}\\\" -asplaintext -force; \$pfx.import(\\\"${cert_path}\\\",\$pfxPass,\\\"Exportable,PersistKeySet\\\"); \$store = New-Object System.Security.Cryptography.X509Certificates.X509Store(\\\"${store_dir}\\\", \\\"${root_store}\\\"); \$store.open(\\\"MaxAllowed\\\"); \$store.add(\$pfx); \$store.close();\"",
+    command   => "${ps_command} -Command \"Import-Module WebAdministration; \$pfx = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection; \$pfx.import(\\\"${cert_path}\\\",\\\"${password}\\\",\\\"Exportable,PersistKeySet\\\"); \$store = New-Object System.Security.Cryptography.X509Certificates.X509Store(\\\"${store_dir}\\\", \\\"${root_store}\\\"); \$store.open(\\\"MaxAllowed\\\"); \$store.addrange(\$pfx); \$store.close();\"",
     onlyif    => "${ps_command} -Command \"Import-Module WebAdministration; if(Get-ChildItem cert:\\ -Recurse | Where-Object {\$_.FriendlyName -match \\\"${name}\\\" } | Select-Object -First 1) { exit 1 } else { exit 0 }\"",
     logoutput => true,
   }


### PR DESCRIPTION
.DC-Ops have reported issue with cert installation when only main certificate was getting installed but not the other internal cert chains.

I fixed this issue by changing the x509Certificates object to be a collection and the other needed changes required for this to work.

I am not sure if its a good idea to add as a seperate class or definition.
