### PR TITLE
Adding more pupept version coverage to the module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-- 1.8.7
 - 1.9.3
 - 2.0.0
 script: bundle exec rake spec


### PR DESCRIPTION
Added coverage for ruby 1.8.7 and 2.0.0 as well as the major puppet versions
