### PR TITLE
Fix references to `sslcert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # SSL Certificate module for Puppet
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-sslcert.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-sslcert)
-[![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-sslcert/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-sslcert)
-[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/sslcert.svg)](https://forge.puppetlabs.com/puppet/sslcert)
-[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/sslcert.svg)](https://forge.puppetlabs.com/puppet/sslcert)
-[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/sslcert.svg)](https://forge.puppetlabs.com/puppet/sslcert)
-[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/sslcert.svg)](https://forge.puppetlabs.com/puppet/sslcert)
+[![Build Status](https://travis-ci.org/voxpupuli/puppet-sslcertificate.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-sslcertificate)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/sslcertificate.svg)](https://forge.puppetlabs.com/puppet/sslcertificate)
+[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/sslcertificate.svg)](https://forge.puppetlabs.com/puppet/sslcertificate)
+[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/sslcertificate.svg)](https://forge.puppetlabs.com/puppet/sslcertificate)
+[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/sslcertificate.svg)](https://forge.puppetlabs.com/puppet/sslcertificate)
 
 #### Table of Contents
 
 1. [Overview](#overview)
 1. [Module Description - What the module does and why it is useful](#module-description)
-1. [Setup - The basics of getting started with sslcert](#setup)
-    * [What sslcert affects](#what-sslcert-affects)
-    * [Beginning with sslcert](#beginning-with-sslcert)
+1. [Setup - The basics of getting started with sslcertificate](#setup)
+    * [What sslcertificate affects](#what-sslcertificate-affects)
+    * [Beginning with sslcertificate](#beginning-with-sslcertificate)
 1. [Usage - Configuration options and additional functionality](#usage)
 1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 1. [Limitations - OS compatibility, etc.](#limitations)
@@ -30,11 +29,11 @@ machines. It will manage pfx, cer, der, p7b, sst certificates.
 
 ## Setup
 
-### What sslcert affects
+### What sslcertificate affects
 
 * Installs certificates into your Windows key stores
 
-### Beginning with sslcert
+### Beginning with sslcertificate
 
   To install a certificate in the My directory of the LocalMachine root store:
 
@@ -66,12 +65,12 @@ machines. It will manage pfx, cer, der, p7b, sst certificates.
 
 ### Classes and Defined Types
 
-#### Defined Type: `sslcert`
+#### Defined Type: `sslcertificate`
 
-The primary definition of the sslcert module. This definition will install the
+The primary definition of the sslcertificate module. This definition will install the
 certificates into your keystore(s).
 
-**Parameters within `sslcert`:**
+**Parameters within `sslcertificate`:**
 
 ##### `password`
 
@@ -99,7 +98,7 @@ The store location for the given certifcation store. Either LocalMachine or Curr
 
 #### Public Definition
 
-* [`sslcert`](#define-sslcert): Guides the installation of certificates
+* [`sslcertificate`](#define-sslcertificate): Guides the installation of certificates
 
 ## Limitations
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name":         "puppet-sslcertificate",
   "version":      "2.1.1",
-  "author":       "puppet-community",
+  "author":       "Vox Pupuli",
   "license":      "MIT",
   "summary":      "Module to manage SSL Certificates on Windows Server 2008 and upwards",
-  "source":       "https://github.com/puppet-community/puppet-sslcert",
-  "project_page": "https://github.com/puppet-community/puppet-sslcert",
-  "issues_url":   "https://github.com/puppet-community/puppet-sslcert/issues",
+  "source":       "https://github.com/voxpupuli/puppet-sslcertificate",
+  "project_page": "https://github.com/voxpupuli/puppet-sslcertificate",
+  "issues_url":   "https://github.com/voxpupuli/puppet-sslcertificate/issues",
   "operatingsystem_support": [
     {
       "operatingsystem": "windows",

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.0.0 <5.0.0"
+    },
+    {
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 1.0.4 <3.0.0"
     }
   ]
 }


### PR DESCRIPTION
Also fix up missing puppetlabs/powershell dependency by cherry-picking commits from https://github.com/voxpupuli/puppet-sslcertificate/pull/24