### PR TITLE
Added a new Exec resource to delete the resulting .ps1 files.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,5 +76,11 @@ define sslcertificate($password, $location, $thumbprint, $root_store = 'LocalMac
     onlyif    => "c:\\temp\\inspect-${name}.ps1",
     logoutput => true,
     require   => [ File["inspect-${name}-certificate.ps1"], File["import-${name}-certificate.ps1"] ],
+    before    => Exec["Clean-${name}-SSLCert-Scripts"] 
+  }
+
+  exec { "Clean-${name}-SSLCert-Scripts":
+    provider  => powershell,
+    command   => "Remove-Item c:\\temp\\*-${name}.ps1",
   }
 }


### PR DESCRIPTION
This happens at the end of the operation of init.pp, and deletes the files so that sensitive data (paths to key files, passwords, etc) is not left in those cleartext files.

Tested operation on a Windows Server 2012 R2 machine.  Each pair of "*-${name}.ps1" gets created, the first Exec runs successfully (and certificates then show in the Certificate Manager), and the second Exec then deletes the pair of files.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
