### PR TITLE
New argument to set exportability of the certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To install a certificate in the My directory of the LocalMachine root store and 
       password       => 'password123',
       location       => 'C:',
       thumbprint     => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
-      is_exportable  => false
+      exportable  => false
   }
 ```
 
@@ -120,7 +120,7 @@ The store location for the given certification store. Either LocalMachine or Cur
 
 The directory where the scripts to verify and install the certificates will be stored. By default is C:\temp
 
-##### `is_exportable`
+##### `exportable`
 Flag to set the key as exportable. `true` == exportable; `false` == not exportable. By default is set to `true`.
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ machines. It will manage pfx, cer, der, p7b, sst certificates.
     }
 ```
 
-  To install a certifcate in an alterntative direcotory:
+  To install a certificate in an alternative directory:
 
 ```puppet
     sslcertificate { "Install-Intermediate-Certificate" :
@@ -56,6 +56,29 @@ machines. It will manage pfx, cer, der, p7b, sst certificates.
       root_store => 'LocalMachine',
       thumbprint => '07E5C1AF7F5223CB975CC29B5455642F5570798B'
     }
+```
+
+To install a certificate in the My directory of the LocalMachine root store using a different directory to store the scripts:
+
+```puppet
+    sslcertificate { "Install-PFX-Certificate" :
+      name          => 'mycert.pfx',
+      password      => 'password123',
+      location      => 'C:',
+      thumbprint    => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+      scripts_dir   => 'C:\scripts_dir'
+    }
+```
+
+To install a certificate in the My directory of the LocalMachine root store and set the key as not exportable:
+```puppet
+    sslcertificate { "Install-PFX-Certificate" :
+      name           => 'mycert.pfx',
+      password       => 'password123',
+      location       => 'C:',
+      thumbprint     => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+      is_exportable  => false
+  }
 ```
 
   For more details on the different options available with certificate management
@@ -74,27 +97,35 @@ certificates into your keystore(s).
 
 ##### `password`
 
-The password for the given certifcate
+The password for the given certificate
 
 ##### `location`
 
-The location to store intermediate certificates
+The location where the file certificate is.
+Do not end the string with any forward or backslash.
 
 ##### `thumbprint`
 
-The thumbprint used to verify the certifcate
+The thumbprint used to verify the certificate
 
 ##### `store_dir`
 
-The certifcate store where the certifcate will be installed to
+The certifcate store where the certificate will be installed to
 
 ##### `root_store`
 
-The store location for the given certifcation store. Either LocalMachine or CurrentUser
+The store location for the given certification store. Either LocalMachine or CurrentUser
+
+##### `scripts_dir`
+
+The directory where the scripts to verify and install the certificates will be stored. By default is C:\temp
+
+##### `is_exportable`
+Flag to set the key as exportable. `true` == exportable; `false` == not exportable. By default is set to `true`.
 
 ## Reference
 
-### Defintion
+### Definition
 
 #### Public Definition
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@
 #    password       => 'password123',
 #    location       => 'C:',
 #    thumbprint     => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
-#    is_exportable  => false
+#    exportable  => false
 #  }
 #
 define sslcertificate (
@@ -85,19 +85,18 @@ define sslcertificate (
   $root_store    = 'LocalMachine',
   $store_dir     = 'My',
   $scripts_dir   = 'C:\temp',
-  $is_exportable = true) {
+  $exportable = true) {
   validate_re($name, '^(.)+$', "Must pass name to ${module_name}[${title}]")
   validate_re($location, '^(.)+$', "Must pass location to ${module_name}[${title}]")
   validate_re($thumbprint, '^(.)+$', "Must pass a certificate thumbprint to ${module_name}[${title}]")
 
   ensure_resource('file', $scripts_dir, {
     ensure => directory
-  }
-  )
+  })
 
-  if($is_exportable){
+  if $exportable {
     $key_storage_flags = 'Exportable,PersistKeySet'
-  }else{
+  } else {
     $key_storage_flags = 'PersistKeySet'
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 # Author::    Paul Stack (mailto:pstack@opentable.com)
 # Copyright:: Copyright (c) 2013 OpenTable Inc
 # License::   MIT
-
 # == Define: sslcertificate
 #
 # This defined type will install SSL Certs on windows
@@ -17,7 +16,8 @@
 # The password for the given certifcate
 #
 # [*location*]
-# The location to store intermediate certificates
+# The location to store intermediate certificates.
+# Do not end the string with any forward or backslash.
 #
 # [*thumbprint*]
 # The thumbprint used to verify the certifcate
@@ -28,6 +28,13 @@
 # [*root_store*]
 # The store location for the given certifcation store. Either LocalMachine or CurrentUser
 #
+# [*scripts_dir*]
+# The directory where the scripts to verify and install the certificates will be stored.
+# By default is C:\temp
+#
+# [*is_exportable*]
+# Flag to set the key as exportable. true == exportable; false == not exportable.
+# By default is set to true.
 # === Examples
 #
 # To install a certificate in the My directory of the LocalMachine root store:
@@ -35,46 +42,84 @@
 #  sslcertificate { "Install-PFX-Certificate" :
 #    name       => 'mycert.pfx',
 #    password   => 'password123',
-#    location   => 'C:\',
+#    location   => 'C:',
 #    thumbprint => '07E5C1AF7F5223CB975CC29B5455642F5570798B'
 #  }
 #
-# To install a certifcate in an alterntative direcotory:
+# To install a certifcate in an alternative directory:
 #
 #  sslcertificate { "Install-Intermediate-Certificate" :
 #    name       => 'go_daddy_intermediate.p7b',
-#    location   => 'C:\',
+#    location   => 'C:',
 #    store_dir  => 'CA',
 #    root_store => 'LocalMachine',
 #    thumbprint => '07E5C1AF7F5223CB975CC29B5455642F5570798B'
 #  }
 #
-define sslcertificate($password, $location, $thumbprint, $root_store = 'LocalMachine', $store_dir = 'My') {
-  validate_re($name, '^(.)+$',"Must pass name to ${module_name}[${title}]")
-  validate_re($location, '^(.)+$',"Must pass location to ${module_name}[${title}]")
+# To install a certificate in the My directory of the LocalMachine root store
+# using a different directory to store the scripts:
+#
+#  sslcertificate { "Install-PFX-Certificate" :
+#    name         => 'mycert.pfx',
+#    password     => 'password123',
+#    location     => 'C:',
+#    thumbprint   => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+#    scripts_dir  => 'C:\scripts_dir'
+#  }
+#
+# To install a certificate in the My directory of the LocalMachine root store
+# and set the key as not exportable:
+#
+#  sslcertificate { "Install-PFX-Certificate" :
+#    name           => 'mycert.pfx',
+#    password       => 'password123',
+#    location       => 'C:',
+#    thumbprint     => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+#    is_exportable  => false
+#  }
+#
+define sslcertificate (
+  $password,
+  $location,
+  $thumbprint,
+  $root_store    = 'LocalMachine',
+  $store_dir     = 'My',
+  $scripts_dir   = 'C:\temp',
+  $is_exportable = true) {
+  validate_re($name, '^(.)+$', "Must pass name to ${module_name}[${title}]")
+  validate_re($location, '^(.)+$', "Must pass location to ${module_name}[${title}]")
   validate_re($thumbprint, '^(.)+$', "Must pass a certificate thumbprint to ${module_name}[${title}]")
 
-  ensure_resource('file', 'C:\temp', { ensure => directory })
+  ensure_resource('file', $scripts_dir, {
+    ensure => directory
+  }
+  )
 
-  file { "inspect-${name}-certificate.ps1" :
-    ensure  => present,
-    path    => "C:\\temp\\inspect-${name}.ps1",
-    content => template('sslcertificate/inspect.ps1.erb'),
-    require => File['C:\temp'],
+  if($is_exportable){
+    $key_storage_flags = 'Exportable,PersistKeySet'
+  }else{
+    $key_storage_flags = 'PersistKeySet'
   }
 
-  file { "import-${name}-certificate.ps1" :
+  file { "inspect-${name}-certificate.ps1":
     ensure  => present,
-    path    => "C:\\temp\\import-${name}.ps1",
+    path    => "${scripts_dir}\\inspect-${name}.ps1",
+    content => template('sslcertificate/inspect.ps1.erb'),
+    require => File[$scripts_dir],
+  }
+
+  file { "import-${name}-certificate.ps1":
+    ensure  => present,
+    path    => "${scripts_dir}\\import-${name}.ps1",
     content => template('sslcertificate/import.ps1.erb'),
-    require => File['C:\temp'],
+    require => File[$scripts_dir],
   }
 
   exec { "Install-${name}-SSLCert":
     provider  => powershell,
-    command   => "c:\\temp\\import-${name}.ps1",
-    onlyif    => "c:\\temp\\inspect-${name}.ps1",
+    command   => "${scripts_dir}\\import-${name}.ps1",
+    onlyif    => "${scripts_dir}\\inspect-${name}.ps1",
     logoutput => true,
-    require   => [ File["inspect-${name}-certificate.ps1"], File["import-${name}-certificate.ps1"] ],
+    require   => [File["inspect-${name}-certificate.ps1"], File["import-${name}-certificate.ps1"]],
   }
 }

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -16,8 +16,8 @@ describe 'sslcertificate', type: :define do
 
     it do
       is_expected.to contain_exec('Install-testCert-SSLCert').with(
-        'command'  => 'c:\temp\import-testCert.ps1',
-        'onlyif'   => 'c:\temp\inspect-testCert.ps1',
+        'command'  => 'C:\temp\import-testCert.ps1',
+        'onlyif'   => 'C:\temp\inspect-testCert.ps1',
         'provider' => 'powershell'
       )
     end
@@ -40,6 +40,90 @@ describe 'sslcertificate', type: :define do
       )
     end
     it { is_expected.to contain_file('inspect-testCert-certificate.ps1').with_content(%r{\$installedCert in \$installedCerts}) }
+  end
+
+  describe 'when managing a ssl certificate specifying a directory for scripts' do
+    let(:title) { 'certificate-testCert' }
+    let(:params) do
+      {
+        name: 'testCert',
+        password: 'testPass',
+        location: 'C:\SslCertificates',
+        thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+        root_store: 'LocalMachine',
+        store_dir: 'My',
+        scripts_dir: 'C:\scripts'
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('Install-testCert-SSLCert').with(
+        'command'  => 'C:\scripts\import-testCert.ps1',
+        'onlyif'   => 'C:\scripts\inspect-testCert.ps1',
+        'provider' => 'powershell'
+      )
+    end
+
+    it do
+      is_expected.to contain_file('import-testCert-certificate.ps1').with(
+        'ensure'  => 'present',
+        'path'    => 'C:\\scripts\\import-testCert.ps1',
+        'require' => 'File[C:\scripts]'
+      )
+    end
+
+    it { is_expected.to contain_file('import-testCert-certificate.ps1').with_content(%r{store.Add}) }
+
+    it do
+      is_expected.to contain_file('inspect-testCert-certificate.ps1').with(
+        'ensure'  => 'present',
+        'path'    => 'C:\\scripts\\inspect-testCert.ps1',
+        'require' => 'File[C:\scripts]'
+      )
+    end
+    it { is_expected.to contain_file('inspect-testCert-certificate.ps1').with_content(%r{\$installedCert in \$installedCerts}) }
+  end
+
+  describe 'when managing a ssl certificate and set the key as not exportable' do
+    let(:title) { 'certificate-testCert' }
+    let(:params) do
+      {
+        name: 'testCert',
+        password: 'testPass',
+        location: 'C:\SslCertificates',
+        thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+        root_store: 'LocalMachine',
+        store_dir: 'My',
+        is_exportable: false
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('Install-testCert-SSLCert').with(
+        'command'  => 'C:\temp\import-testCert.ps1',
+        'onlyif'   => 'C:\temp\inspect-testCert.ps1',
+        'provider' => 'powershell'
+      )
+    end
+
+    it do
+      is_expected.to contain_file('import-testCert-certificate.ps1').with(
+        'ensure'  => 'present',
+        'path'    => 'C:\\temp\\import-testCert.ps1',
+        'require' => 'File[C:\temp]'
+      )
+    end
+
+    it { is_expected.to contain_file('import-testCert-certificate.ps1').without_content(%r{Exportable,PersistKeySet}) }
+
+    it do
+      is_expected.to contain_file('inspect-testCert-certificate.ps1').with(
+        'ensure'  => 'present',
+        'path'    => 'C:\\temp\\inspect-testCert.ps1',
+        'require' => 'File[C:\temp]'
+      )
+    end
+    it { is_expected.to contain_file('inspect-testCert-certificate.ps1').without_content(%r{Exportable,PersistKeySet}) }
   end
 
   describe 'when empty certificate name is provided' do

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -94,7 +94,7 @@ describe 'sslcertificate', type: :define do
         thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
         root_store: 'LocalMachine',
         store_dir: 'My',
-        is_exportable: false
+        exportable: false
       }
     end
 

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -1,21 +1,21 @@
 $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2
 
-$cert = gi <%= @location %>/<%= @name %>
+$cert = gi "<%= @location %>\<%= @name %>"
 
 switch -regex ($cert.Extension.ToUpper()) {
     ".CER|.DER|.P12" {
-        $pfx.import("<%= @location %>\\<%= @name %>","<%= @password %>","Exportable,PersistKeySet")
+        $pfx.import("<%= @location %>\<%= @name %>","<%= @password %>","<%= @key_storage_flags %>")
     }
     ".CRT" {
-        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\\<%= @name %>"))
+        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\<%= @name %>"))
     }
     ".P7B|.SST" {
         $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\\<%= @name %>"))
+        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\<%= @name %>"))
     }
     ".PFX" {
         $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        $pfx.import("<%= @location %>\\<%= @name %>","<%= @password %>","Exportable,PersistKeySet")
+        $pfx.import("<%= @location %>\<%= @name %>","<%= @password %>","<%= @key_storage_flags %>")
     }
 }
 

--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -1,20 +1,20 @@
 $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2
 
-$certificate = gi <%= @location %>\<%= @name %>
+$certificate = gi "<%= @location %>\<%= @name %>"
 switch -regex ($certificate.Extension.ToUpper()) {
     ".CER|.DER|.P12" {
-        $pfx.import("<%= @location %>\\<%= @name %>","<%= @password %>","Exportable,PersistKeySet")
+        $pfx.import("<%= @location %>\<%= @name %>","<%= @password %>","<%= @key_storage_flags %>")
     }
     ".CRT" {
-        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\\<%= @name %>"))
+        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\<%= @name %>"))
     }
     ".P7B|.SST" {
         $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\\<%= @name %>"))
+        $pfx.Import([System.IO.File]::ReadAllBytes("<%= @location %>\<%= @name %>"))
     }
     ".PFX" {
         $pfx = new-object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
-        $pfx.import("<%= @location %>\\<%= @name %>","<%= @password %>","Exportable,PersistKeySet")
+        $pfx.import("<%= @location %>\<%= @name %>","<%= @password %>","<%= @key_storage_flags %>")
     }
 }
 


### PR DESCRIPTION
Adding a new argument to specify the location of the scripts. README updated with this info. Spec tests added. Tests use a different certificate thumbprint.The test certificate is spec/testCert.pfx

This is a combined pull it contains two features: 
#45 (new argument to specify a directory to store the scripts) and #46 itself (flag to set the exportability of the certificate key).

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
