### PR TITLE
Set mode to 0600 on sensitive scripts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@ define sslcertificate (
     path    => "${scripts_dir}\\inspect-${name}.ps1",
     content => template('sslcertificate/inspect.ps1.erb'),
     require => File[$scripts_dir],
+    mode    => '0600',
   }
 
   file { "import-${name}-certificate.ps1":
@@ -112,6 +113,7 @@ define sslcertificate (
     path    => "${scripts_dir}\\import-${name}.ps1",
     content => template('sslcertificate/import.ps1.erb'),
     require => File[$scripts_dir],
+    mode    => '0600',
   }
 
   exec { "Install-${name}-SSLCert":


### PR DESCRIPTION
Those scripts contain sensitive data ; we should keep them unreadable
for everyone.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
