### PR TITLE
Don't store the PS1 scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,6 @@ machines. It will manage pfx, cer, der, p7b, sst certificates.
     }
 ```
 
-To install a certificate in the My directory of the LocalMachine root store using a different directory to store the scripts:
-
-```puppet
-    sslcertificate { "Install-PFX-Certificate" :
-      name          => 'mycert.pfx',
-      password      => 'password123',
-      location      => 'C:',
-      thumbprint    => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
-      scripts_dir   => 'C:\scripts_dir'
-    }
-```
-
 To install a certificate in the My directory of the LocalMachine root store and set the key as not exportable:
 ```puppet
     sslcertificate { "Install-PFX-Certificate" :
@@ -118,9 +106,10 @@ The store location for the given certification store. Either LocalMachine or Cur
 
 ##### `scripts_dir`
 
-The directory where the scripts to verify and install the certificates will be stored. By default is C:\temp
+This parameter has been deprecated and isn't used anymore. The scripts aren't saved to disk anymore.
 
 ##### `exportable`
+
 Flag to set the key as exportable. `true` == exportable; `false` == not exportable. By default is set to `true`.
 
 ## Reference

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -16,72 +16,11 @@ describe 'sslcertificate', type: :define do
 
     it do
       is_expected.to contain_exec('Install-testCert-SSLCert').with(
-        'command'  => 'C:\temp\import-testCert.ps1',
-        'onlyif'   => 'C:\temp\inspect-testCert.ps1',
         'provider' => 'powershell'
-      )
+      ).
+        with_command(%r{\$cert = gi "C:\\SslCertificates\\testCert"}).
+        with_onlyif(%r{\$certificate = gi "C:\\SslCertificates\\testCert"})
     end
-
-    it do
-      is_expected.to contain_file('import-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\temp\\import-testCert.ps1',
-        'require' => 'File[C:\temp]'
-      )
-    end
-
-    it { is_expected.to contain_file('import-testCert-certificate.ps1').with_content(%r{store.Add}) }
-
-    it do
-      is_expected.to contain_file('inspect-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\temp\\inspect-testCert.ps1',
-        'require' => 'File[C:\temp]'
-      )
-    end
-    it { is_expected.to contain_file('inspect-testCert-certificate.ps1').with_content(%r{\$installedCert in \$installedCerts}) }
-  end
-
-  describe 'when managing a ssl certificate specifying a directory for scripts' do
-    let(:title) { 'certificate-testCert' }
-    let(:params) do
-      {
-        name: 'testCert',
-        password: 'testPass',
-        location: 'C:\SslCertificates',
-        thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
-        root_store: 'LocalMachine',
-        store_dir: 'My',
-        scripts_dir: 'C:\scripts'
-      }
-    end
-
-    it do
-      is_expected.to contain_exec('Install-testCert-SSLCert').with(
-        'command'  => 'C:\scripts\import-testCert.ps1',
-        'onlyif'   => 'C:\scripts\inspect-testCert.ps1',
-        'provider' => 'powershell'
-      )
-    end
-
-    it do
-      is_expected.to contain_file('import-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\scripts\\import-testCert.ps1',
-        'require' => 'File[C:\scripts]'
-      )
-    end
-
-    it { is_expected.to contain_file('import-testCert-certificate.ps1').with_content(%r{store.Add}) }
-
-    it do
-      is_expected.to contain_file('inspect-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\scripts\\inspect-testCert.ps1',
-        'require' => 'File[C:\scripts]'
-      )
-    end
-    it { is_expected.to contain_file('inspect-testCert-certificate.ps1').with_content(%r{\$installedCert in \$installedCerts}) }
   end
 
   describe 'when managing a ssl certificate and set the key as not exportable' do
@@ -100,30 +39,11 @@ describe 'sslcertificate', type: :define do
 
     it do
       is_expected.to contain_exec('Install-testCert-SSLCert').with(
-        'command'  => 'C:\temp\import-testCert.ps1',
-        'onlyif'   => 'C:\temp\inspect-testCert.ps1',
         'provider' => 'powershell'
-      )
+      ).
+        with_command(%r{\$cert = gi "C:\\SslCertificates\\testCert"}).
+        with_onlyif(%r{\$certificate = gi "C:\\SslCertificates\\testCert"})
     end
-
-    it do
-      is_expected.to contain_file('import-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\temp\\import-testCert.ps1',
-        'require' => 'File[C:\temp]'
-      )
-    end
-
-    it { is_expected.to contain_file('import-testCert-certificate.ps1').without_content(%r{Exportable,PersistKeySet}) }
-
-    it do
-      is_expected.to contain_file('inspect-testCert-certificate.ps1').with(
-        'ensure'  => 'present',
-        'path'    => 'C:\\temp\\inspect-testCert.ps1',
-        'require' => 'File[C:\temp]'
-      )
-    end
-    it { is_expected.to contain_file('inspect-testCert-certificate.ps1').without_content(%r{Exportable,PersistKeySet}) }
   end
 
   # TODO: this needs to be corrected


### PR DESCRIPTION
Prior to this, the module creates the set and check scripts as files on
disk. This meant that the passwords and script information would be left
hanging around.

This fixes that by building the check and set scripts only when running
the exec. The exec's "command" and "onlyif" parameters now build the
templates directly rather than use the scripts on disk.

I've left the "scripts_dir" parameter around for backward
compatibility. It doesn't do anything, but leaving it around means that
people's existing code won't break.

In a X release of this module, that deprecated parameter should be
removed.

Before merging this, someone should check that the sslcertificate type actually works. There are no acceptance tests, so manual verification is needed.