### PR TITLE
Grant permission to user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ define sslcertificate (
   String[1] $store_dir             = 'My',
   Stdlib::Windowspath $scripts_dir = 'C:\temp',
   Boolean $exportable              = true,
-  String $grant_user               = '',
+  String $grant_user               = undef,
 ) {
 
   if $exportable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,8 @@ define sslcertificate (
   String[1] $root_store            = 'LocalMachine',
   String[1] $store_dir             = 'My',
   Stdlib::Windowspath $scripts_dir = 'C:\temp',
-  Boolean $exportable              = true
+  Boolean $exportable              = true,
+  String $grant_user               = '',
 ) {
 
   if $exportable {

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -71,7 +71,7 @@ describe 'sslcertificate', type: :define do
         thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
         root_store: 'LocalMachine',
         store_dir: 'My',
-        grant_user: 'test-cert-user',
+        grant_user: 'test-cert-user'
       }
     end
 

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -60,4 +60,27 @@ describe 'sslcertificate', type: :define do
 
     it { is_expected.to contain_exec('Install-testCert-SSLCert') }
   end
+
+  describe 'when managing a ssl certificate and set a user to access the private key' do
+    let(:title) { 'certificate-testCert-privkey' }
+    let(:params) do
+      {
+        name: 'testCert',
+        password: 'testPass',
+        location: 'C:\SslCertificates',
+        thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+        root_store: 'LocalMachine',
+        store_dir: 'My',
+        grant_user: 'test-cert-user',
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('Install-testCert-SSLCert').with(
+        'provider' => 'powershell'
+      ).
+        with_command(%r{icacls \$fullpath /grant test-cert-user:RX}).
+        with_onlyif(%r{\$certificate = gi "C:\\SslCertificates\\testCert"})
+    end
+  end
 end

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -37,3 +37,10 @@ foreach($cert in $pfx) {
 $store.close()
 
 Remove-Item $MyINvocation.InvocationName
+
+if([string]::IsNullOrEmpty("<%= @grant_user %>")) {
+    $keyname=(((gci cert:\<%= @root_store %>\<%= @store_dir %> | ? {$_.thumbprint -like <%= @thumbprint %>}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName
+    $fullpath = $env:ProgramData + "\Microsoft\Crypto\RSA\MachineKeys\" + $keyname
+    icacls $fullpath /grant <%= @grant_user %>:RX
+}
+

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -43,3 +43,4 @@ if([string]::IsNullOrEmpty("<%= @grant_user %>") -eq $False) {
 }
 
 Remove-Item $MyINvocation.InvocationName
+

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -36,11 +36,10 @@ foreach($cert in $pfx) {
 
 $store.close()
 
-Remove-Item $MyINvocation.InvocationName
-
-if([string]::IsNullOrEmpty("<%= @grant_user %>")) {
-    $keyname=(((gci cert:\<%= @root_store %>\<%= @store_dir %> | ? {$_.thumbprint -like <%= @thumbprint %>}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName
+if([string]::IsNullOrEmpty("<%= @grant_user %>") -eq $False) {
+    $keyname=(((gci cert:\<%= @root_store %>\<%= @store_dir %> | ? {$_.thumbprint -like "<%= @thumbprint %>" }).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName
     $fullpath = $env:ProgramData + "\Microsoft\Crypto\RSA\MachineKeys\" + $keyname
     icacls $fullpath /grant <%= @grant_user %>:RX
 }
 
+Remove-Item $MyINvocation.InvocationName


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
Added a little feature in order to specify a user to whom should be granted access to the private key of a certificate being installed.

Inspired by this blog post:

https://blogs.technet.microsoft.com/operationsguy/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell/