### PR TITLE
Introduce machine key set flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,9 +32,14 @@
 # [*scripts_dir*]
 # This parameter has been deprecated and is no longer used.
 #
-# [*is_exportable*]
+# [*exportable*]
 # Flag to set the key as exportable. true == exportable; false == not exportable.
 # By default is set to true.
+#
+# [*use_machine_key_storage*]
+# Flag to mark a potential provate key to be stored within the machine key storage (as compared to the use key storage)
+# true == store private keys in the machine key storage, false == store private keys in the user key storage.
+# By default is set to false.
 # === Examples
 #
 # To install a certificate in the My directory of the LocalMachine root store:
@@ -60,10 +65,10 @@
 # and set the key as not exportable:
 #
 #  sslcertificate { "Install-PFX-Certificate" :
-#    name           => 'mycert.pfx',
-#    password       => 'password123',
-#    location       => 'C:',
-#    thumbprint     => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+#    name        => 'mycert.pfx',
+#    password    => 'password123',
+#    location    => 'C:',
+#    thumbprint  => '07E5C1AF7F5223CB975CC29B5455642F5570798B',
 #    exportable  => false
 #  }
 #
@@ -73,10 +78,10 @@ define sslcertificate (
   Optional[String[1]] $password    = undef,
   String[1] $root_store            = 'LocalMachine',
   String[1] $store_dir             = 'My',
-  Stdlib::Windowspath $scripts_dir = 'C:\temp',
+  Stdlib::Windowspath $scripts_dir = 'C:\\temp',
   Boolean $exportable              = true,
   Boolean $wildcard                = false,
-  Boolean $interstore              = false
+  Boolean $interstore              = false,
 ) {
 
   if $exportable {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I've run into the problem that private keys imported from .pfx files are not accessible when using the certificates within IIS. Obviously this is because the keys are installed into the user key storage instead of the machine key storage.

This was fixed by adding the 'MachineKeySet' storage flag when calling X509Certificates.import() (also refer to: https://stackoverflow.com/questions/36867243/what-is-the-impact-of-the-persistkeyset-storageflag-when-importing-a-certifica). This flag is controlled by the new 'use_machine_key_storage' parameter.

Additional change:
 - removed the 'Remove-Item $MyINvocation.InvocationName' in both Powershell template files as these are only useful if temporary ps1 files are created. This is not the case any more.

#### This Pull Request (PR) fixes the following issues
Addresses #25 
@hpAB also suggests to introduce this flag within the comments
