### PR TITLE
Add wildcard & bypass Intermediate Store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Flag to set the key as exportable. `true` == exportable; `false` == not exportab
 
 Flag to set the MachineKeySet flag in import, used for importing wildcard certificates. Defaults to `false`
 
+##### `interstore`
+
+If this is set to `true`, any intermediate certificates included will be imported in the same store_dir, not the intermediate store.
+Defaults to `false`
+
 ## Reference
 
 ### Definition

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ This parameter has been deprecated and isn't used anymore. The scripts aren't sa
 
 Flag to set the key as exportable. `true` == exportable; `false` == not exportable. By default is set to `true`.
 
+##### `wildcard`
+
+Flag to set the MachineKeySet flag in import, used for importing wildcard certificates. Defaults to `false`
+
 ## Reference
 
 ### Definition

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,8 +75,8 @@ define sslcertificate (
   String[1] $store_dir             = 'My',
   Stdlib::Windowspath $scripts_dir = 'C:\temp',
   Boolean $exportable              = true,
-  Optional[Boolean] $wildcard      = false,
-  Optional[Boolean] $interstore    = false
+  Boolean $wildcard                = false,
+  Boolean $interstore              = false
 ) {
 
   if $exportable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,8 @@ define sslcertificate (
   String[1] $store_dir             = 'My',
   Stdlib::Windowspath $scripts_dir = 'C:\temp',
   Boolean $exportable              = true,
-  Optional[Boolean] $wildcard      = false
+  Optional[Boolean] $wildcard      = false,
+  Optional[Boolean] $interstore    = false
 ) {
 
   if $exportable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,11 +74,16 @@ define sslcertificate (
   String[1] $root_store            = 'LocalMachine',
   String[1] $store_dir             = 'My',
   Stdlib::Windowspath $scripts_dir = 'C:\temp',
-  Boolean $exportable              = true
+  Boolean $exportable              = true,
+  Optional[Boolean] $wildcard      = false
 ) {
 
   if $exportable {
-    $key_storage_flags = 'Exportable,PersistKeySet'
+    if $wildcard {
+      $key_storage_flags = 'MachineKeySet,Exportable,PersistKeySet'
+    } else {
+      $key_storage_flags = 'Exportable,PersistKeySet'
+    }
   } else {
     $key_storage_flags = 'PersistKeySet'
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-sslcertificate",
-  "version": "3.4.1-rc0",
+  "version": "3.4.1-rc1",
   "author": "Vox Pupuli",
   "license": "MIT",
   "summary": "Module to manage SSL Certificates on Windows Server 2008 and upwards",
@@ -14,7 +14,8 @@
         "2008",
         "2008 R2",
         "2012",
-        "2012 R2"
+        "2012 R2",
+        "2016"
       ]
     }
   ],

--- a/spec/defines/sslcertificate_spec.rb
+++ b/spec/defines/sslcertificate_spec.rb
@@ -60,4 +60,29 @@ describe 'sslcertificate', type: :define do
 
     it { is_expected.to contain_exec('Install-testCert-SSLCert') }
   end
+
+  describe 'when managing a wildcard certificate and interstore is enabled' do
+    let(:title) { 'certificate-testCert' }
+    let(:params) do
+      {
+        name: 'testCert',
+        password: 'testPass',
+        location: 'C:\SslCertificates',
+        thumbprint: '07E5C1AF7F5223CB975CC29B5455642F5570798B',
+        root_store: 'LocalMachine',
+        store_dir: 'My',
+        wildcard: true,
+        exportable: true,
+        interstore: true
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('Install-testCert-SSLCert').with(
+        'provider' => 'powershell'
+      ).
+        with_command(%r{\$cert = gi "C:\\SslCertificates\\testCert"}).
+        with_onlyif(%r{\$certificate = gi "C:\\SslCertificates\\testCert"})
+    end
+  end
 end

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -25,13 +25,18 @@ $store.open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite
 $intermediatestore = new-object System.Security.Cryptography.X509Certificates.X509Store("CA","<%= @root_store %>")
 $intermediatestore.open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
 
+<% if @interstore == true %>
+foreach($cert in $pfx) {
+    $store.Add($cert)
+}
+<% else %>
 foreach($cert in $pfx) {
   if($cert.Thumbprint -ne "<%= @thumbprint %>") {
-      $intermediatestore.Add($cert)
-  }
-  else {
-      $store.Add($cert)
+    $intermediatestore.Add($cert)
+  } else {
+    $store.Add($cert)
   }
 }
+<% end %>
 
 $store.close()

--- a/templates/import.ps1.erb
+++ b/templates/import.ps1.erb
@@ -35,5 +35,3 @@ foreach($cert in $pfx) {
 }
 
 $store.close()
-
-Remove-Item $MyINvocation.InvocationName

--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -48,14 +48,11 @@ if (($pfx -ne $null) -and ($installedCerts -ne $null) -and ($intermediateCerts -
     # When $pfx.Count is $null, $pfx is an instance of X509Certificate2, not X509Certificate2Collection, so
     # ensure that only a single certificate has been installed.
     if (($pfx.Count -eq $null) -and ($installedCertCount -eq 1) -and ($installedIntermediateCount -eq 0)) {
-        Remove-Item $MyINvocation.InvocationName
         exit 1
     }
     elseif (($installedCertCount + $installedIntermediateCount) -eq $pfx.Count) {
-        Remove-Item $MyINvocation.InvocationName
         exit 1
     }
 }
 
-Remove-Item $MyINvocation.InvocationName
 exit 0


### PR DESCRIPTION
#### Pull Request (PR) description

1. This PR adds 2 new flags:
 - wildcard
There are some other pending PRs that implement this in much the same way.
Setting this to true will add "MachineKeySet" to the key_storage_flags
This has only been tested where the certificate is also a wildcard

 - interstore
Setting this to true will store intermediate certs bundled into the chain in the target store_dir

There is a new test that just sets all the optional flags to true.

2. Remove the template calls to Remove-Item

Now that https://github.com/voxpupuli/puppet-sslcertificate/pull/66 is merged, the invoked templates do not need to be removed each run.

3. Version bump and include support for Server 2016