### PR TITLE
No need to remove the running temp file

### DIFF
--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -1,7 +1,6 @@
 $is_already_installed = Get-ChildItem -Path cert:\<%= @root_store %>\<%= @store_dir %> -Recurse  | select thumbprint | where { $_.thumbprint -eq '<%= @thumbprint %>' }
 
 if ([string]::IsNullOrEmpty($is_already_installed) -eq $False) {
-    Remove-Item $MyINvocation.InvocationName
     exit 1
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Puppet does not require template scripts to be removed.

The `Remove-Item $MyINvocation.InvocationName` generates the following exception:

> Remove-Item : Cannot bind argument to parameter 'Path' because it is an empty string.

Completes the changes merged via https://github.com/voxpupuli/puppet-sslcertificate/pull/84

#### This Pull Request (PR) fixes the following issues
n/a