### PR TITLE
Added quotes to fix paths with spaces

### DIFF
--- a/templates/inspect.ps1.erb
+++ b/templates/inspect.ps1.erb
@@ -1,4 +1,4 @@
-$is_already_installed = Get-ChildItem -Path cert:\<%= @root_store %>\<%= @store_dir %> -Recurse  | select thumbprint | where { $_.thumbprint -eq '<%= @thumbprint %>' }
+$is_already_installed = Get-ChildItem -Path "cert:\<%= @root_store %>\<%= @store_dir %>" -Recurse  | select thumbprint | where { $_.thumbprint -eq '<%= @thumbprint %>' }
 
 if ([string]::IsNullOrEmpty($is_already_installed) -eq $False) {
     Remove-Item $MyINvocation.InvocationName
@@ -26,8 +26,8 @@ switch -regex ($certificate.Extension.ToUpper()) {
 }
 
 
-$installedCerts = @(Get-ChildItem -R cert:\<%= @root_store %>\<%= @store_dir %>)
-$intermediateCerts = @(Get-ChildItem -R cert:\<%= @root_store %>\CA)
+$installedCerts = @(Get-ChildItem -R "cert:\<%= @root_store %>\<%= @store_dir %>")
+$intermediateCerts = @(Get-ChildItem -R "cert:\<%= @root_store %>\CA")
 
 $installedCertCount = 0
 $installedIntermediateCount = 0


### PR DESCRIPTION
I tried using this module with: 

`store_dir => 'Trusted Root Certification Authorities'`

This will break the "inspect.ps1" script with syntax errors (because of the spaces used in the path) resulting in exit code 1 (even if the certificate is installed). Which results in a "change" on every puppet run.
To overcome this I'm now temporarily using extra quotes in the store_dir parameter

`store_dir => '"Trusted Root Certification Authorities"'`

Note that this does NOT work for fresh deployments. So I use it without the extra quotes to deploy and add the extra quotes afterwards to keep it working
